### PR TITLE
filter for squads that are available to the user

### DIFF
--- a/impectPy/iteration_averages.py
+++ b/impectPy/iteration_averages.py
@@ -31,7 +31,7 @@ def getPlayerIterationAverages(iteration: int, token: str) -> pd.DataFrame:
     ).process_response()
 
     # get squadIds
-    squad_ids = squads.id.to_list()
+    squad_ids = squads[squads.access].id.to_list()
 
     # get player iteration averages per squad
     averages_raw = pd.concat(


### PR DESCRIPTION
Previously, the `getPlayerIterationAverages()` function queried the squads endpoint and then iterated over all squads returned. Now the returned squad list is filtered for squads the user has access to prior to iterating.