### PR TITLE
Duplicates in events with multi match query

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# impectPy 2.0.3
+
+## Minor changes
+* fix bug in `getEvents()` function caused by querying data for multiple iterations of the same competition
+
 # impectPy 2.0.2
 
 ## Minor changes

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A package provided by: Impect GmbH
 
-Version: v2.0.2
+Version: v2.0.3
 
-**Updated: July 27th 2023**
+**Updated: July 28th 2023**
 
 ---
 
@@ -30,7 +30,7 @@ You can install the latest version of impectPy from
 [GitHub](https://github.com/) with:
 
 ``` cmd
-pip install git+https://github.com/ImpectAPI/impectPy.git@v2.0.2
+pip install git+https://github.com/ImpectAPI/impectPy.git@v2.0.3
 ```
 
 ## Getting started

--- a/impectPy/events.py
+++ b/impectPy/events.py
@@ -36,7 +36,7 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
             matchId=match
         ),
             matches),
-        ignore_index=True)
+        ignore_index=True).drop_duplicates()
 
     # get event scorings
     scorings = pd.concat(
@@ -46,7 +46,7 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             matches),
-        ignore_index=True)
+        ignore_index=True).drop_duplicates()
 
     # get match info
     iterations = pd.concat(
@@ -69,7 +69,7 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             iterations),
-        ignore_index=True)
+        ignore_index=True)[["id", "commonname"]].drop_duplicates()
 
     # get squads
     squads = pd.concat(
@@ -79,7 +79,7 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             iterations),
-        ignore_index=True)
+        ignore_index=True)[["id", "name"]].drop_duplicates()
 
     # get kpis
     kpis = rate_limited_api.make_api_request_limited(

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
                       "pandas>=2.0.0",
                       "numpy>=1.24.2"],
     # *strongly* suggested for sharing
-    version="2.0.2",
+    version="2.0.3",
     # The license can be anything you like
     license="MIT",
     description="A Python package to facilitate interaction with the Impect customer API",


### PR DESCRIPTION
When getting event data for multiple matches from different iterations of the same competition, a list of squads containing duplicates is returned. This causes the duplication of events when merging events squads.

To address this issue alongside other potential issues of the same nature with other returned data frames, duplicates from the events, scorings, squads and players data frames will be removed.