### PR TITLE
remove duplicates from squads and players before merging

### DIFF
--- a/impectPy/matchsums.py
+++ b/impectPy/matchsums.py
@@ -58,7 +58,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             iterations),
-        ignore_index=True)
+        ignore_index=True)[["id", "commonname"]].drop_duplicates()
 
     # get squads
     squads = pd.concat(
@@ -68,7 +68,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             iterations),
-        ignore_index=True)
+        ignore_index=True)[["id", "name"]].drop_duplicates()
 
     # get kpis
     kpis = rate_limited_api.make_api_request_limited(
@@ -274,7 +274,7 @@ def getSquadMatchsums(matches: list, token: str) -> pd.DataFrame:
             headers=my_header
         ).process_response(),
             iterations),
-        ignore_index=True)
+        ignore_index=True)[["id", "name"]].drop_duplicates()
 
     # get kpis
     kpis = rate_limited_api.make_api_request_limited(


### PR DESCRIPTION
When getting matchsums data for multiple matches from different iterations of the same competition, a list of squads/players containing duplicates is returned. This causes the duplication of events when merging matchsums with squads/players.

To address this issue alongside other potential issues of the same nature with other returned data frames, duplicates from the squads and players data frames will be removed prior to merging.