### PR TITLE
select only required columns from kpi endpoint response

### DIFF
--- a/impectPy/events.py
+++ b/impectPy/events.py
@@ -110,7 +110,7 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
         headers=my_header
     ).process_response(
         endpoint="EventKPIs"
-    )
+    )[["id", "name"]]
 
     # get matches
     matchplan = pd.concat(

--- a/impectPy/iteration_averages.py
+++ b/impectPy/iteration_averages.py
@@ -67,7 +67,7 @@ def getPlayerIterationAverages(iteration: int, token: str) -> pd.DataFrame:
         headers=my_header
     ).process_response(
         endpoint="KPIs"
-    )
+    )[["id", "name"]]
 
     # get iterations
     iterations = getIterations(token=token, session=rate_limited_api.session)
@@ -213,7 +213,7 @@ def getSquadIterationAverages(iteration: int, token: str) -> pd.DataFrame:
         headers=my_header
     ).process_response(
         endpoint="KPIs"
-    )
+    )[["id", "name"]]
 
     # get iterations
     iterations = getIterations(token=token, session=rate_limited_api.session)

--- a/impectPy/matchsums.py
+++ b/impectPy/matchsums.py
@@ -97,7 +97,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
         headers=my_header
     ).process_response(
         endpoint="KPIs"
-    )
+    )[["id", "name"]]
 
     # get matches
     matchplan = pd.concat(
@@ -324,7 +324,7 @@ def getSquadMatchsums(matches: list, token: str) -> pd.DataFrame:
         headers=my_header
     ).process_response(
         endpoint="KPIs"
-    )
+    )[["id", "name"]]
 
     # get matches
     matchplan = pd.concat(


### PR DESCRIPTION
A fix was applied to the following functions:

- `getEvents()`
- `getPlayerMatchsums()`
- `getSquadMatchsums()`
- `getPlayerIterationAverages()`
- `getSquadIterationAverages()`

The required columns `id` and `name` are now selected explicitly and the newly added columns are ignored.