### PR TITLE
Fix panda issues

### DIFF
--- a/impectPy/events.py
+++ b/impectPy/events.py
@@ -209,10 +209,10 @@ def getEvents(matches: list, token: str) -> pd.DataFrame:
         .reset_index() \
         .loc[lambda df: df["eventId"].notna()]
 
-    # Replace empty strings with NaN in the eventId and playerId column
-    scorings["eventId"].replace('', np.nan, inplace=True)
-    scorings["playerId"].replace('', np.nan, inplace=True)
-    events["playerId"].replace('', np.nan, inplace=True)
+    # Replace empty strings with None in the eventId and playerId column
+    scorings["eventId"] = scorings["eventId"].mask(scorings["eventId"] == '', None)
+    scorings["playerId"] = scorings["playerId"].mask(scorings["playerId"] == '', None)
+    events["playerId"] = events["playerId"].mask(events["playerId"] == '', None)
 
     # Convert column eventId from float to int
     scorings["eventId"] = scorings["eventId"].astype(pd.Int64Dtype())

--- a/impectPy/matchsums.py
+++ b/impectPy/matchsums.py
@@ -132,7 +132,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
             )
 
             # extract matchshares
-            matchshares = temp[["matchId", "id", "position", "matchShare", "playDuration"]].drop_duplicates()
+            matchshares = temp[["matchId", "squadId", "id", "position", "matchShare", "playDuration"]].drop_duplicates()
 
             # explode kpis column
             temp = temp.explode("kpis")
@@ -168,8 +168,8 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
             temp = pd.merge(
                 temp,
                 matchshares,
-                left_on=["id", "position"],
-                right_on=["id", "position"],
+                left_on=["matchId", "squadId", "id", "position"],
+                right_on=["matchId", "squadId", "id", "position"],
                 how="inner",
                 suffixes=("", "_right")
             )
@@ -427,7 +427,16 @@ def getSquadMatchsums(matches: list, token: str) -> pd.DataFrame:
     # add kpiNames to order
     order += kpis['name'].to_list()
 
-    # select columns
+    # filter for non-NA columns only
+    matchsums = matchsums[
+        (matchsums.matchId.notnull()) &
+        (matchsums.squadId.notnull())
+    ]
+
+    # reset index
+    matchsums = matchsums.reset_index()
+
+    # select & order columns
     matchsums = matchsums[order]
 
     # return data


### PR DESCRIPTION
Starting from pandas version 2.1, there occurred issues with duplicates that resulted from a change in the way the pandas merge function works. Code was added that filters out those duplicates and half-empty rows.

Also, starting with pandas 3.0 the replace method will be adjusted and certain functionality will no longer function as expected. The code was already adjusted for this.