### PR TITLE
add playerName back in after previously removing it

### DIFF
--- a/impectPy/iteration_averages.py
+++ b/impectPy/iteration_averages.py
@@ -137,7 +137,9 @@ def getPlayerIterationAverages(iteration: int, token: str) -> pd.DataFrame:
         how="left",
         suffixes=("", "_right")
     ).merge(
-        players[["id", "firstname", "lastname", "birthdate", "birthplace", "leg"]],
+        players[["id", "commonname", "firstname", "lastname", "birthdate", "birthplace", "leg"]].rename(
+            columns={"commonname": "playerName"}
+        ),
         left_on="playerId",
         right_on="id",
         how="left",
@@ -160,6 +162,7 @@ def getPlayerIterationAverages(iteration: int, token: str) -> pd.DataFrame:
         "squadId",
         "squadName",
         "playerId",
+        "playerName",
         "firstname",
         "lastname",
         "birthdate",

--- a/impectPy/matchsums.py
+++ b/impectPy/matchsums.py
@@ -77,7 +77,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
                 endpoint="Players"
             ),
             iterations),
-        ignore_index=True)[["id", "firstname", "lastname", "birthdate", "birthplace", "leg"]].drop_duplicates()
+        ignore_index=True)[["id", "commonname", "firstname", "lastname", "birthdate", "birthplace", "leg"]].drop_duplicates()
 
     # get squads
     squads = pd.concat(
@@ -200,7 +200,9 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
         how="left",
         suffixes=("", "_right")
     ).merge(
-        players[["id", "firstname", "lastname", "birthdate", "birthplace", "leg"]],
+        players[["id", "commonname", "firstname", "lastname", "birthdate", "birthplace", "leg"]].rename(
+            columns={"commonname": "playerName"}
+        ),
         left_on="id",
         right_on="id",
         how="left",
@@ -227,6 +229,7 @@ def getPlayerMatchsums(matches: list, token: str) -> pd.DataFrame:
         "squadId",
         "squadName",
         "playerId",
+        "playerName",
         "firstname",
         "lastname",
         "birthdate",


### PR DESCRIPTION
With a previous commit, the column "playerName" was replaced by "firstname" and "lastname". However, as for dome players, firstname and/or lastname are Null, the playerName had to be added back in.