### PR TITLE
Use raw string notation for regex to avoid SyntaxWarning

### DIFF
--- a/impectPy/helpers.py
+++ b/impectPy/helpers.py
@@ -190,7 +190,7 @@ def process_response(self: requests.Response, endpoint: str) -> pd.DataFrame:
     result = pd.json_normalize(result)
 
     # fix column names using regex
-    result = result.rename(columns=lambda x: re.sub("\.(.)", lambda y: y.group(1).upper(), x))
+    result = result.rename(columns=lambda x: re.sub(r"\.(.)", lambda y: y.group(1).upper(), x))
 
     # return result
     return result


### PR DESCRIPTION
When using this library we get a `SyntaxWarning` in our logs, this should sort it...

https://docs.python.org/3/library/re.html

> Regular expressions use the backslash character ('\') to indicate special forms or to allow special characters to be used without invoking their special meaning. This collides with Python’s usage of the same character for the same purpose in string literals; for example, to match a literal backslash, one might have to write '\\\\' as the pattern string, because the regular expression must be \\, and each backslash must be expressed as \\ inside a regular Python string literal. Also, please note that any invalid escape sequences in Python’s usage of the backslash in string literals now generate a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) and in the future this will become a [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError). This behaviour will happen even if it is a valid escape sequence for a regular expression.

> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with 'r'. So r"\n" is a two-character string containing '\' and 'n', while "\n" is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.