### PR TITLE
fix: resolve numpy 2.0 compatibility issues in generateXML()

### DIFF
--- a/impectPy/generate_xml.py
+++ b/impectPy/generate_xml.py
@@ -130,8 +130,8 @@ def generateXML(
         p4Start: int,
         p5Start: int,
         codeTag: str,
-        squad: None,
-        perspective: None,
+        squad=None,
+        perspective=None,
         labels=None,
         kpis=None,
         labelSorting: bool = True,
@@ -561,10 +561,7 @@ def generateXML(
         players["teamGoals"] == players["opponentGoals"], "tied",
         np.where(
             players["teamGoals"] > players["opponentGoals"], "leading",
-            np.where(
-                players["teamGoals"] < players["opponentGoals"], "trailing",
-                np.NaN
-            )
+            "trailing"
         )
     )
 
@@ -820,7 +817,7 @@ def generateXML(
     players["actionTypeResult"] = np.where(
         players["result"].notna(),
         players["actionType"] + "_" + players["result"],
-        np.NaN
+        None
     )
 
     # add data to xml structure


### PR DESCRIPTION
## Summary

Fixes #170

- `squad: None` / `perspective: None` changed to `squad=None` / `perspective=None` — they were type annotations without default values, making the parameters required instead of optional
- Removed redundant innermost `np.where` for `"trailing"` game state; NumPy 2.0 rejects mixing `str` dtype with `np.nan` (float), and the branch was logically redundant anyway
- `np.nan` → `None` in `actionTypeResult` np.where fallback for the same dtype reason; downstream XML writing already filters out `"None"` values

## Test plan

- [x] Run `generateXML()` with `squad=None, perspective=None` — should no longer require explicit values
- [x] Verify no `DTypePromotionError` or `AttributeError` raised with NumPy 2.0+
- [x] Confirm generated XML output is valid and unchanged for normal inputs